### PR TITLE
feat: run spooker on workflow completion

### DIFF
--- a/lib/Utils.groovy
+++ b/lib/Utils.groovy
@@ -1,0 +1,42 @@
+class Utils {
+    // run spooker for the workflow
+    public static String spooker(workflow) {
+        def pipeline_name = "${workflow.manifest.name.tokenize('/')[-1]}"
+        def command_string = "spooker ${workflow.launchDir} ${pipeline_name}"
+        def out = new StringBuilder()
+        def err = new StringBuilder()
+        def spooker_in_path = check_command_in_path("spooker")
+        if (spooker_in_path) {
+            try {
+                println "Running spooker"
+                def command = command_string.execute()
+                command.consumeProcessOutput(out, err)
+                command.waitFor()
+            } catch(IOException e) {
+                err = e
+            }
+            new FileWriter("${workflow.launchDir}/log/spooker.log").with {
+                write("${out}\n${err}")
+                flush()
+            }
+        } else {
+            err = "spooker not found, skipping"
+        }
+        return err
+    }
+    // check whether a command is in the path
+    public static Boolean check_command_in_path(cmd) {
+        def command_string = "command -V ${cmd}"
+        def out = new StringBuilder()
+        def err = new StringBuilder()
+        try {
+            def command = command_string.execute()
+            command.consumeProcessOutput(out, err)
+            command.waitFor()
+        } catch(IOException e) {
+            err = e
+        }
+        return err.length()==0
+
+    }
+}

--- a/main.nf
+++ b/main.nf
@@ -36,6 +36,14 @@ log.info """\
          """
          .stripIndent()
 
+workflow.onComplete {
+    if (!workflow.stubRun && !workflow.commandLine.contains('-preview')) {
+        def message = Utils.spooker(workflow)
+        if (message) {
+            println message
+        }
+    }
+}
 
 //Final Workflow
 workflow {


### PR DESCRIPTION
When a workflow completes (regardless of success or failure), check whether the spooker command is available, and if so, run it to track usage statistics.