### PR TITLE
Configure pre-commit

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,46 @@
+default_install_hook_types: [pre-commit, commit-msg]
+default_stages: [pre-commit]
+exclude: |
+  (?x)(
+      ^assets/|
+      ^docs/.*.html
+   )
+repos:
+  - repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v1.2.3
+    hooks:
+      - id: check-added-large-files
+      - id: end-of-file-fixer
+      - id: trailing-whitespace
+  # spell check
+  - repo: https://github.com/codespell-project/codespell
+    rev: v2.2.4
+    hooks:
+      - id: codespell
+        # https://github.com/codespell-project/codespell/issues/1498
+  # Python formatting
+  - repo: https://github.com/psf/black
+    rev: 23.7.0
+    hooks:
+      - id: black
+  # R formatting
+  - repo: https://github.com/lorenzwalthert/precommit
+    rev: v0.1.2
+    hooks:
+      - id: style-files
+  # general linting
+  - repo: https://github.com/pre-commit/mirrors-prettier
+    rev: v2.7.1
+    hooks:
+      - id: prettier
+  # enforce commit format
+  - repo: https://github.com/compilerla/conventional-pre-commit
+    rev: v2.3.0
+    hooks:
+      - id: conventional-pre-commit
+        stages: [commit-msg]
+        args: []
+  - repo: https://github.com/citation-file-format/cffconvert
+    rev: 054bda51dbe278b3e86f27c890e3f3ac877d616c
+    hooks:
+      - id: validate-cff

--- a/.prettierignore
+++ b/.prettierignore
@@ -1,0 +1,8 @@
+# gitignore
+.nextflow*
+work/
+data/
+results/
+.DS_Store
+*.code-workspace
+assets/*.html

--- a/.prettierrc
+++ b/.prettierrc
@@ -1,0 +1,4 @@
+overrides:
+  - files: "*.md"
+    options:
+      tabWidth: 2


### PR DESCRIPTION
Adds various pre-commit hooks to style files and make sure formats are valid. Run `pre-commit install` in your clone after merging this to install the hooks and start using pre-commit.